### PR TITLE
Fix for larger screens

### DIFF
--- a/src/components/FirewatchParallax.js
+++ b/src/components/FirewatchParallax.js
@@ -20,8 +20,12 @@ const ParallaxLayer = styled.div`
   top: 0;
   right: 0;
   bottom: 0;
-  left: -25%;
-  width: 150%;
+  left: 0;
+  width: 100%;
+  @media only screen and (max-width: 900px) {
+    left: -20%;
+    width: 150%;
+  }
   @media only screen and (max-width: 900px) {
     left: -50%;
     width: 200%;

--- a/src/components/FirewatchParallax.js
+++ b/src/components/FirewatchParallax.js
@@ -22,7 +22,7 @@ const ParallaxLayer = styled.div`
   bottom: 0;
   left: 0;
   width: 100%;
-  @media only screen and (max-width: 900px) {
+  @media only screen and (max-width: 2000px) {
     left: -20%;
     width: 150%;
   }


### PR DESCRIPTION
I repurposed your code for a project that I'm working on (as I found that it was more optimized than the original from Sam). 

However, I realized that the rendering of both on your netlify instance and my project wasn't great on my iMac 27". 

<img width="2558" alt="image" src="https://user-images.githubusercontent.com/4112343/59892187-1a809780-93a6-11e9-8b4b-a43f53014e5c.png">

and now with my suggestion:
<img width="2560" alt="image" src="https://user-images.githubusercontent.com/4112343/59892243-46038200-93a6-11e9-8af1-869dcb3f0134.png">


This is the fix I came up with - it does the job in my project but you might want to QA it here.